### PR TITLE
Added redirectOriginOverride

### DIFF
--- a/flutter_web_auth_2/lib/flutter_web_auth_2.dart
+++ b/flutter_web_auth_2/lib/flutter_web_auth_2.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
 
 export 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
@@ -41,11 +42,21 @@ class FlutterWebAuth2 {
   /// [preferEphemeral] if this is specified as `true`, an ephemeral web browser
   /// session will be used where possible (`FLAG_ACTIVITY_NO_HISTORY` on
   /// Android, `prefersEphemeralWebBrowserSession` on iOS/macOS).
+  ///
+  /// [redirectOriginOverride] is used to override the origin of the redirect
+  /// URL. This is useful for cases where the redirect URL is not on the same
+  /// domain (ex. local testing)
   static Future<String> authenticate({
     required String url,
     required String callbackUrlScheme,
     bool? preferEphemeral,
+    String? redirectOriginOverride,
   }) async {
+    assert(
+      redirectOriginOverride == null || kDebugMode,
+      'Do not use redirectOriginOverride in production',
+    );
+
     WidgetsBinding.instance.removeObserver(
       _resumedObserver,
     ); // safety measure so we never add this observer twice
@@ -54,6 +65,7 @@ class FlutterWebAuth2 {
       url: url,
       callbackUrlScheme: callbackUrlScheme,
       preferEphemeral: preferEphemeral ?? false,
+      redirectOriginOverride: redirectOriginOverride,
     );
   }
 

--- a/flutter_web_auth_2/lib/src/flutter_web_auth_2_web.dart
+++ b/flutter_web_auth_2/lib/src/flutter_web_auth_2_web.dart
@@ -27,6 +27,8 @@ class FlutterWebAuth2WebPlugin extends FlutterWebAuth2Platform {
           url: url,
           callbackUrlScheme: '',
           preferEphemeral: false,
+          redirectOriginOverride:
+              call.arguments['redirectOriginOverride']?.toString(),
         );
       default:
         throw PlatformException(
@@ -42,10 +44,11 @@ class FlutterWebAuth2WebPlugin extends FlutterWebAuth2Platform {
     required String url,
     required String callbackUrlScheme,
     required bool preferEphemeral,
+    String? redirectOriginOverride,
   }) async {
     context.callMethod('open', [url]);
     await for (final MessageEvent messageEvent in window.onMessage) {
-      if (messageEvent.origin == Uri.base.origin) {
+      if (messageEvent.origin == (redirectOriginOverride ?? Uri.base.origin)) {
         final flutterWebAuthMessage = messageEvent.data['flutter-web-auth-2'];
         if (flutterWebAuthMessage is String) {
           return flutterWebAuthMessage;

--- a/flutter_web_auth_2/lib/src/flutter_web_auth_2_windows.dart
+++ b/flutter_web_auth_2/lib/src/flutter_web_auth_2_windows.dart
@@ -58,6 +58,7 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
     required String url,
     required String callbackUrlScheme,
     required bool preferEphemeral,
+    String? redirectOriginOverride,
   }) async {
     // Validate callback url
     final callbackUri = Uri.parse(callbackUrlScheme);

--- a/flutter_web_auth_2/pubspec.yaml
+++ b/flutter_web_auth_2/pubspec.yaml
@@ -24,6 +24,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:
+  flutter_web_auth_2_platform_interface:
+    path: ../flutter_web_auth_2_platform_interface
+
 flutter:
   plugin:
     platforms:

--- a/flutter_web_auth_2_platform_interface/lib/flutter_web_auth_2_platform_interface.dart
+++ b/flutter_web_auth_2_platform_interface/lib/flutter_web_auth_2_platform_interface.dart
@@ -27,11 +27,13 @@ abstract class FlutterWebAuth2Platform extends PlatformInterface {
     required String url,
     required String callbackUrlScheme,
     required bool preferEphemeral,
+    String? redirectOriginOverride,
   }) =>
       _instance.authenticate(
         url: url,
         callbackUrlScheme: callbackUrlScheme,
         preferEphemeral: preferEphemeral,
+        redirectOriginOverride: redirectOriginOverride,
       );
 
   Future clearAllDanglingCalls() => _instance.clearAllDanglingCalls();

--- a/flutter_web_auth_2_platform_interface/lib/method_channel/method_channel_flutter_web_auth_2.dart
+++ b/flutter_web_auth_2_platform_interface/lib/method_channel/method_channel_flutter_web_auth_2.dart
@@ -10,11 +10,13 @@ class FlutterWebAuth2MethodChannel extends FlutterWebAuth2Platform {
     required String url,
     required String callbackUrlScheme,
     required bool preferEphemeral,
+    String? redirectOriginOverride,
   }) async =>
       await channel.invokeMethod<String>('authenticate', <String, dynamic>{
         'url': url,
         'callbackUrlScheme': callbackUrlScheme,
         'preferEphemeral': preferEphemeral,
+        'redirectOriginOverride': redirectOriginOverride,
       }) ??
       '';
 


### PR DESCRIPTION
I wanted to test OAuth locally, but the web implementation only processes messages from the same domain. I added a parameter to override the redirect origin for testing so that the MessageEvent can be processed.