### PR TITLE
Update build.gradle

### DIFF
--- a/flutter_web_auth_2/android/build.gradle
+++ b/flutter_web_auth_2/android/build.gradle
@@ -44,5 +44,5 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
Getting `Execution failed for task ':app:checkDebugDuplicateClasses'.` after adding `appwrite` dependency on fresh Flutter project (appwrite uses `flutter_web_auth_2` internally). The reason was because of conflicting kotlin version. And this we believe was because kotlin 1.8 dropped support for java 6 and 7. The proposed change should fix this issue.

- https://github.com/appwrite/sdk-for-flutter/issues/133
- https://github.com/appwrite/sdk-generator/issues/626
