### PR TITLE
Use semantic versioning and fix incompatible versions from main and interface package #41

### DIFF
--- a/flutter_web_auth_2/CHANGELOG.md
+++ b/flutter_web_auth_2/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- 🐛 fix platforms version and use semantic versioning ([#31](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/41)) 
+
 ## 2.1.3
 
 - 🌹 Add `contextArgs` for web implementations (See [#40](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/40))

--- a/flutter_web_auth_2/pubspec.yaml
+++ b/flutter_web_auth_2/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_web_auth_2
 description: Flutter plugin for authenticating a user with a web service.
-version: 2.1.3
+version: 2.2.0
 homepage: https://github.com/ThexXTURBOXx/flutter_web_auth_2
 repository: https://github.com/ThexXTURBOXx/flutter_web_auth_2
 issue_tracker: https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues
@@ -12,10 +12,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_web_auth_2_platform_interface: ^2.1.0
+  flutter_web_auth_2_platform_interface: ^2.2.0
   flutter_web_plugins:
     sdk: flutter
-  url_launcher: ^6.1.6
+  url_launcher: ^6.1.10
   window_to_front: ^0.0.3
 
 dev_dependencies:

--- a/flutter_web_auth_2_platform_interface/CHANGELOG.md
+++ b/flutter_web_auth_2_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0
+
+- 🌹 update packages and use semantic versioning (
+  See [#41](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/41))
+
 ## 2.1.3
 
 - 🌹 Add `contextArgs` for web implementations (See [#40](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/40))

--- a/flutter_web_auth_2_platform_interface/pubspec.yaml
+++ b/flutter_web_auth_2_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_web_auth_2_platform_interface
 description: A common platform interface for the flutter_web_auth_2 plugin.
-version: 2.1.3
+version: 2.2.0
 homepage: https://github.com/ThexXTURBOXx/flutter_web_auth_2
 repository: https://github.com/ThexXTURBOXx/flutter_web_auth_2
 issue_tracker: https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.1.2
+  plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
update version from flutter_web_auth_2_platform_interface in flutter_web_auth_2 and use semantic versioning

we need to deploy the platform interface version first, so that pubspec can resolve it in the main package

Related to #41 