### PR TITLE
added fallback for window.opener being null

### DIFF
--- a/flutter_web_auth_2/README.md
+++ b/flutter_web_auth_2/README.md
@@ -135,9 +135,14 @@ On the web platform, an endpoint must be created that captures the callback URL 
 <title>Authentication complete</title>
 <p>Authentication is complete. If this does not happen automatically, please close the window.</p>
 <script>
-  window.opener.postMessage({
-    'flutter-web-auth-2': window.location.href
-  }, window.location.origin);
+    if(window.opener) {
+        window.opener.postMessage({
+        'flutter-web-auth-2': window.location.href
+        }, window.location.origin);
+    } else {
+        //if window.opener is null, we fallback to the local storage approach.
+        localStorage.setItem('flutter-web-auth-2', window.location.href);
+    }
   window.close();
 </script>
 ```

--- a/flutter_web_auth_2/lib/src/flutter_web_auth_2_web.dart
+++ b/flutter_web_auth_2/lib/src/flutter_web_auth_2_web.dart
@@ -39,7 +39,7 @@ class FlutterWebAuth2WebPlugin extends FlutterWebAuth2Platform {
     }
   }
 
-  @override
+   @override
   Future<String> authenticate({
     required String url,
     required String callbackUrlScheme,
@@ -52,77 +52,87 @@ class FlutterWebAuth2WebPlugin extends FlutterWebAuth2Platform {
     
     //new method using local storage as a work-around 
     //for some browsers & oauth implementations
-    if(window.opener == null) {
+
       //remove the old record if it exists
       const storageKey = 'flutter-web-auth-2';
-      const Duration timeout = const Duration(minutes: 5);
+      const timeout = Duration(minutes: 5);
       window.localStorage.remove(storageKey);
       final timeoutTime = DateTime.now().add(timeout);
-
+      Timer? lsTimer;
+      StreamSubscription? messageSubscription;
       final completer = Completer<String>();
-
-      //periodicity check for the callback value in local storage.
-      //if it exists, return it.  if not, check the timeout.
-      //if the timeout has passed, throw an exception.
-      Timer.periodic(const Duration(seconds: 1), (timer) {
-        
-        if(window.localStorage.containsKey(storageKey)) {
-          final flutterWebAuthMessage = window.localStorage[storageKey];
-          if (flutterWebAuthMessage is String) {
-            completer.complete(flutterWebAuthMessage);
-            window.localStorage.remove(storageKey);
-            timer.cancel();
-          } else {
-            completer.completeError(PlatformException(
+      try{
+        //periodicity check for the callback value in local storage.
+        //if it exists, return it.  if not, check the timeout.
+        //if the timeout has passed, throw an exception.
+        lsTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+          
+          if(window.localStorage.containsKey(storageKey)) {
+            final flutterWebAuthMessage = window.localStorage[storageKey];
+            if (flutterWebAuthMessage is String) {
+              completer.complete(flutterWebAuthMessage);
+              window.localStorage.remove(storageKey);
+              messageSubscription?.cancel();
+              timer.cancel();
+            } else {
+              throw PlatformException(
+                code: 'error',
+                message: 'Callback value is not a string',
+              );
+            }
+          } else if(DateTime.now().isAfter(timeoutTime)) {
+            throw PlatformException(
               code: 'error',
-              message: 'Callback value is not a string',
-            ),);
-            timer.cancel();
+              message: 'Timeout waiting for callback value',
+            );
           }
-        } else if(DateTime.now().isAfter(timeoutTime)) {
-          completer.completeError(PlatformException(
-            code: 'error',
-            message: 'Timeout waiting for callback value',
-          ),);
-          timer.cancel();
-        }
-      });
+        });
+
+      
+
+        //Traditional window.opener method of listening for the redirect
+        messageSubscription = window.onMessage.listen((MessageEvent messageEvent) {
+
+          if (messageEvent.origin == (redirectOriginOverride ?? Uri.base.origin)) {
+            final flutterWebAuthMessage = messageEvent.data['flutter-web-auth-2'];
+            if (flutterWebAuthMessage is String) {
+              lsTimer?.cancel();
+              messageSubscription?.cancel();
+              completer.complete(flutterWebAuthMessage);
+            }
+          }
+
+          final appleOrigin = Uri(scheme: 'https', host: 'appleid.apple.com');
+          if (messageEvent.origin == appleOrigin.toString()) {
+            try {
+              final data = jsonDecode(messageEvent.data.toString());
+              if (data['method'] == 'oauthDone') {
+                final appleAuth =
+                    data['data']['authorization'] as Map<String, dynamic>?;
+                if (appleAuth != null) {
+                  final appleAuthQuery = Uri(queryParameters: appleAuth).query;
+                  lsTimer?.cancel();
+                  messageSubscription?.cancel();
+                  completer.complete(appleOrigin.replace(fragment: appleAuthQuery).toString());
+                }
+              }
+            } on FormatException {
+              // ignore exception
+            }
+
+          }
+      },
+        onError: (error) {
+          lsTimer?.cancel();
+          messageSubscription?.cancel();
+          throw error;
+        },
+      );
+      } catch(e) {
+        lsTimer?.cancel();
+        completer.completeError(e);
+      }
 
       return completer.future;
-      
-    } else {
-    
-
-      //Traditional window.opener method of listening for the redirect
-      await for (final MessageEvent messageEvent in window.onMessage) {
-        if (messageEvent.origin == (redirectOriginOverride ?? Uri.base.origin)) {
-          final flutterWebAuthMessage = messageEvent.data['flutter-web-auth-2'];
-          if (flutterWebAuthMessage is String) {
-            return flutterWebAuthMessage;
-          }
-        }
-        final appleOrigin = Uri(scheme: 'https', host: 'appleid.apple.com');
-        if (messageEvent.origin == appleOrigin.toString()) {
-          try {
-            final data = jsonDecode(messageEvent.data.toString());
-            if (data['method'] == 'oauthDone') {
-              final appleAuth =
-                  data['data']['authorization'] as Map<String, dynamic>?;
-              if (appleAuth != null) {
-                final appleAuthQuery = Uri(queryParameters: appleAuth).query;
-                return appleOrigin.replace(fragment: appleAuthQuery).toString();
-              }
-            }
-          } on FormatException {
-            // ignore exception
-          }
-        }
-      }
-      throw PlatformException(
-        code: 'error',
-        message: 'Iterable window.onMessage is empty',
-      );
-    }
-
   }
 }


### PR DESCRIPTION
Fixes #44 

Implements a secondary method of relaying the callback url to flutter by using local storage. 

The new `auth.html` javascript would look like this.
```js
    if(window.opener) {
        window.opener.postMessage({
        'flutter-web-auth-2': window.location.href
        }, window.location.origin);
    } else {
        //if window.opener is null, we fallback to the local storage approach.
        localStorage.setItem('flutter-web-auth-2', window.location.href);
    }
   window.close();
```