### PR TITLE
Adds compileOptions to build.gradle

### DIFF
--- a/flutter_web_auth_2/android/build.gradle
+++ b/flutter_web_auth_2/android/build.gradle
@@ -28,6 +28,11 @@ android {
     compileSdkVersion 33
     namespace 'com.linusu.flutter_web_auth_2'
 
+    compileOptions {
+        sourceCompatibility project.sourceCompatibility
+        targetCompatibility project.targetCompatibility
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
Adds source & target compatibility options into build.gradle, to resolve a compilation error with newer versions of gradle (8+ from what I've seen)

The error:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_web_auth_2:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
```