### PR TITLE
[Windows] Add support for custom callback schemes

### DIFF
--- a/flutter_web_auth_2/example/lib/main.dart
+++ b/flutter_web_auth_2/example/lib/main.dart
@@ -7,8 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 
-const html =
-    '''
+const html = '''
 <!DOCTYPE html>
 <html>
 <head>

--- a/flutter_web_auth_2/example/lib/main.dart
+++ b/flutter_web_auth_2/example/lib/main.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'dart:io' show HttpServer, Platform;
 
+import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 
-const html = '''
+const html =
+    '''
 <!DOCTYPE html>
 <html>
 <head>
@@ -63,7 +65,12 @@ const html = '''
 </html>
 ''';
 
-void main() => runApp(const MyApp());
+void main(List<String> args) {
+  if (runWebViewTitleBarWidget(args)) {
+    return;
+  }
+  runApp(const MyApp());
+}
 
 class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
@@ -95,7 +102,7 @@ class MyAppState extends State<MyApp> {
 
       // Windows needs some callback URL on localhost
       req.response.write(
-        (Platform.isWindows || Platform.isLinux)
+        (Platform.isLinux)
             ? html.replaceFirst(
                 'CALLBACK_URL_HERE',
                 'http://localhost:43824/success?code=1337',
@@ -110,7 +117,7 @@ class MyAppState extends State<MyApp> {
     });
   }
 
-  Future<void> authenticate() async {
+  Future<void> authenticate(BuildContext context) async {
     setState(() {
       _status = '';
     });
@@ -122,9 +129,7 @@ class MyAppState extends State<MyApp> {
 
     // Windows needs some callback URL on localhost
     final callbackUrlScheme =
-        !kIsWeb && (Platform.isWindows || Platform.isLinux)
-            ? 'http://localhost:43824'
-            : 'foobar';
+        !kIsWeb && (Platform.isLinux) ? 'http://localhost:43824' : 'foobar';
 
     try {
       final result = await FlutterWebAuth2.authenticate(
@@ -157,7 +162,9 @@ class MyAppState extends State<MyApp> {
                 Text('Status: $_status\n'),
                 const SizedBox(height: 80),
                 ElevatedButton(
-                  onPressed: authenticate,
+                  onPressed: () async {
+                    await authenticate(context);
+                  },
                   child: const Text('Authenticate'),
                 ),
               ],

--- a/flutter_web_auth_2/example/lib/main.dart
+++ b/flutter_web_auth_2/example/lib/main.dart
@@ -116,7 +116,7 @@ class MyAppState extends State<MyApp> {
     });
   }
 
-  Future<void> authenticate(BuildContext context) async {
+  Future<void> authenticate() async {
     setState(() {
       _status = '';
     });
@@ -162,7 +162,7 @@ class MyAppState extends State<MyApp> {
                 const SizedBox(height: 80),
                 ElevatedButton(
                   onPressed: () async {
-                    await authenticate(context);
+                    await authenticate();
                   },
                   child: const Text('Authenticate'),
                 ),

--- a/flutter_web_auth_2/example/pubspec.yaml
+++ b/flutter_web_auth_2/example/pubspec.yaml
@@ -11,8 +11,7 @@ dependencies:
   desktop_webview_window: ^0.2.3
   flutter:
     sdk: flutter
-  flutter_web_auth_2:
-    path: ../../flutter_web_auth_2
+  flutter_web_auth_2: ^3.0.0
 
 dev_dependencies:
   flutter_lints: ^3.0.0

--- a/flutter_web_auth_2/example/pubspec.yaml
+++ b/flutter_web_auth_2/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
   cupertino_icons: ^1.0.3
   flutter:
     sdk: flutter
-  flutter_web_auth_2: ^3.0.0
+  flutter_web_auth_2:
+    path: ../../flutter_web_auth_2
 
 dev_dependencies:
   flutter_lints: ^3.0.0

--- a/flutter_web_auth_2/example/pubspec.yaml
+++ b/flutter_web_auth_2/example/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   cupertino_icons: ^1.0.3
+  desktop_webview_window: ^0.2.3
   flutter:
     sdk: flutter
   flutter_web_auth_2:

--- a/flutter_web_auth_2/lib/flutter_web_auth_2.dart
+++ b/flutter_web_auth_2/lib/flutter_web_auth_2.dart
@@ -10,6 +10,7 @@ export 'src/options.dart';
 export 'src/unsupported.dart'
     if (dart.library.io) 'src/server.dart'
     if (dart.library.html) 'src/web.dart';
+export 'src/windows.dart';
 
 class _OnAppLifecycleResumeObserver extends WidgetsBindingObserver {
   final Function onResumed;

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:desktop_webview_window/desktop_webview_window.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
 
 class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
@@ -44,6 +45,14 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
         webview?.close();
       }
     });
+    unawaited(webview!.onClose.whenComplete(() => {
+          if (!authenticated)
+            {
+              c.completeError(
+                PlatformException(code: 'CANCELED', message: 'User canceled'),
+              )
+            },
+        }));
     webview!.launch(url);
     return c.future;
   }

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:desktop_webview_window/desktop_webview_window.dart';
+import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
+
+class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
+  static void registerWith() {
+    FlutterWebAuth2Platform.instance = FlutterWebAuth2WindowsPlugin();
+  }
+
+  @override
+  Future<String> authenticate({
+    required String url,
+    required String callbackUrlScheme,
+    required Map<String, dynamic> options,
+  }) async {
+    if (!await WebviewWindow.isWebviewAvailable()) {
+      throw StateError('Webview is not available');
+    }
+    final c = Completer<String>();
+    final webview = await WebviewWindow.create(
+      configuration: CreateConfiguration(
+        windowHeight: 720,
+        windowWidth: 1280,
+        title: 'easyroam authentication',
+        titleBarTopPadding: Platform.isMacOS ? 20 : 0,
+      ),
+    );
+    webview.addOnUrlRequestCallback((url) {
+      final uri = Uri.parse(url);
+      if (uri.scheme == callbackUrlScheme) {
+        c.complete(url);
+        webview.close();
+      }
+    });
+    webview.launch(url);
+    return c.future;
+  }
+}

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -5,6 +5,9 @@ import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
 
 class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
+  bool authenticated = false;
+  Webview? webview;
+
   static void registerWith() {
     FlutterWebAuth2Platform.instance = FlutterWebAuth2WindowsPlugin();
   }
@@ -16,25 +19,32 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
     required Map<String, dynamic> options,
   }) async {
     if (!await WebviewWindow.isWebviewAvailable()) {
+      //Microsofts WebView2 must be installed for this to work
       throw StateError('Webview is not available');
     }
+    //Reset
+    authenticated = false;
+    webview?.close();
+
     final c = Completer<String>();
-    final webview = await WebviewWindow.create(
+
+    webview = await WebviewWindow.create(
       configuration: CreateConfiguration(
         windowHeight: 720,
         windowWidth: 1280,
-        title: 'easyroam authentication',
+        title: 'Authenticate',
         titleBarTopPadding: Platform.isMacOS ? 20 : 0,
       ),
     );
-    webview.addOnUrlRequestCallback((url) {
+    webview!.addOnUrlRequestCallback((url) {
       final uri = Uri.parse(url);
       if (uri.scheme == callbackUrlScheme) {
+        authenticated = true;
         c.complete(url);
-        webview.close();
+        webview?.close();
       }
     });
-    webview.launch(url);
+    webview!.launch(url);
     return c.future;
   }
 }

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -45,19 +45,28 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
       final uri = Uri.parse(url);
       if (uri.scheme == callbackUrlScheme) {
         authenticated = true;
-        c.complete(url);
         webview?.close();
+        /**
+         * Not setting the webview to null will cause a crash if the 
+         * application tries to open another webview
+         */
+        webview = null;
+        c.complete(url);
       }
     });
     unawaited(
       webview!.onClose.whenComplete(
-        () => {
-          if (!authenticated)
-            {
-              c.completeError(
-                PlatformException(code: 'CANCELED', message: 'User canceled'),
-              ),
-            },
+        () {
+          /**
+           * Not setting the webview to null will cause a crash if the 
+           * application tries to open another webview
+           */
+          webview = null;
+          if (!authenticated) {
+            c.completeError(
+              PlatformException(code: 'CANCELED', message: 'User canceled'),
+            );
+          }
         },
       ),
     );

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -50,14 +50,18 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
         webview?.close();
       }
     });
-    unawaited(webview!.onClose.whenComplete(() => {
+    unawaited(
+      webview!.onClose.whenComplete(
+        () => {
           if (!authenticated)
             {
               c.completeError(
                 PlatformException(code: 'CANCELED', message: 'User canceled'),
-              )
+              ),
             },
-        }));
+        },
+      ),
+    );
     webview!.launch(url);
     return c.future;
   }

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:desktop_webview_window/desktop_webview_window.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
+import 'package:path_provider/path_provider.dart';
 
 class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
   bool authenticated = false;
@@ -28,13 +30,16 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
     webview?.close();
 
     final c = Completer<String>();
-
+    debugPrint(
+      '''Launching webview with url: $url, callbackUrlScheme: $callbackUrlScheme, tmpDir: ${(await getTemporaryDirectory()).path}''',
+    );
     webview = await WebviewWindow.create(
       configuration: CreateConfiguration(
         windowHeight: 720,
         windowWidth: 1280,
         title: 'Authenticate',
         titleBarTopPadding: Platform.isMacOS ? 20 : 0,
+        userDataFolderWindows: (await getTemporaryDirectory()).path,
       ),
     );
     webview!.addOnUrlRequestCallback((url) {

--- a/flutter_web_auth_2/lib/src/windows.dart
+++ b/flutter_web_auth_2/lib/src/windows.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flutter/cupertino.dart';
@@ -38,7 +37,7 @@ class FlutterWebAuth2WindowsPlugin extends FlutterWebAuth2Platform {
         windowHeight: 720,
         windowWidth: 1280,
         title: 'Authenticate',
-        titleBarTopPadding: Platform.isMacOS ? 20 : 0,
+        titleBarTopPadding: 0,
         userDataFolderWindows: (await getTemporaryDirectory()).path,
       ),
     );

--- a/flutter_web_auth_2/pubspec.yaml
+++ b/flutter_web_auth_2/pubspec.yaml
@@ -24,6 +24,7 @@ environment:
   flutter: ">=3.0.0"
 
 dependencies:
+  desktop_webview_window: ^0.2.3
   flutter:
     sdk: flutter
   flutter_web_auth_2_platform_interface: ^3.0.0
@@ -54,5 +55,5 @@ flutter:
         pluginClass: FlutterWebAuth2WebPlugin
         fileName: src/web.dart
       windows:
-        dartPluginClass: FlutterWebAuth2ServerPlugin
-        fileName: src/server.dart
+        dartPluginClass: FlutterWebAuth2WindowsPlugin
+        fileName: src/windows.dart

--- a/flutter_web_auth_2/pubspec.yaml
+++ b/flutter_web_auth_2/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   flutter_web_auth_2_platform_interface: ^3.0.0
   flutter_web_plugins:
     sdk: flutter
+  path_provider: ^2.1.2
   url_launcher: ^6.1.6
   window_to_front: ^0.0.3
 


### PR DESCRIPTION
This PR adds supports for custom callback schemes during authentication on Windows, by opening a new instance of the application that displays a webview (Microsoft WebView2).

### Potential issues?
- Microsoft WebView2 must be installed or packaged with the app (preinstalled as part of Windows 11 and on some Windows 10 devices but not all) [Read more](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution)
- App developers must add the following code snippet to their main function to block the webview window from executing code twice 
```dart
void main(List<String> args) {
//Add this
  if (runWebViewTitleBarWidget(args)) {
    return;
  }
//---
  runApp(const MyApp());
}
```
- Will break the old way of using this library (using `http://localhost` as the scheme) as there will no longer be a local server that listens for calls

fixes #25 
And should also (hopefully) fix #73 