### PR TITLE
Loosen constraint on web dependency to ease transition to 1.0.0

### DIFF
--- a/flutter_web_auth_2/pubspec.yaml
+++ b/flutter_web_auth_2/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   path_provider: ^2.1.2
   url_launcher: ^6.1.6
-  web: ^1.0.0
+  web: ">=0.5.0 <2.0.0"
   window_to_front: ^0.0.3
 
 dev_dependencies:


### PR DESCRIPTION
There are still packages stuck on `web: ^0.5.0`. There don't seem to be any changes that affect this package, so we can use the range `web: ">=0.5.0 <2.0.0"` to support those packages.