### PR TITLE
Default to chrome at the end

### DIFF
--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/FlutterWebAuth2Plugin.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/FlutterWebAuth2Plugin.kt
@@ -82,10 +82,6 @@ class FlutterWebAuth2Plugin(
      */
     private fun findTargetBrowserPackageName(options: Map<String, Any>): String? {
         val chromePackage = "com.android.chrome"
-        //if installed chrome, use chrome at first
-        if (isSupportCustomTabs(chromePackage)) {
-            return chromePackage
-        }
 
         @Suppress("UNCHECKED_CAST")
         val customTabsPackageOrder = (options["customTabsPackageOrder"] as Iterable<String>?) ?: emptyList()
@@ -104,6 +100,9 @@ class FlutterWebAuth2Plugin(
         val allBrowsers = getInstalledBrowsers()
         targetPackage = allBrowsers.firstOrNull { isSupportCustomTabs(it) }
 
+        if (targetPackage == null) {
+            targetPackage = chromePackage
+        }
         return targetPackage
     }
 


### PR DESCRIPTION
We are using a custom browser and even though Chrome is installed, we need to have this browser selected among the list of passed browsers. Therefore I removed the forcing of chrome and moved it at the bottom in case the target browser is null