### PR TITLE
iOS: Add SceneDelegate handling to fix ACQUIRE_ROOT_VIEW_CONTROLLER_FAILED 

### DIFF
--- a/flutter_web_auth_2/ios/Classes/SwiftFlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/ios/Classes/SwiftFlutterWebAuth2Plugin.swift
@@ -87,18 +87,25 @@ public class SwiftFlutterWebAuth2Plugin: NSObject, FlutterPlugin {
                 if #available(iOS 13, *) {
                     var rootViewController: UIViewController? = nil
 
+                    // Try to get root view controller from the scene delegate if available
+                    if rootViewController == nil {
+	                    if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+	                        rootViewController = scene.windows.first?.rootViewController
+	                    }
+                    }
+
                     // FlutterViewController
-                    if (rootViewController == nil) {
+                    if rootViewController == nil {
                         rootViewController = UIApplication.shared.delegate?.window??.rootViewController as? FlutterViewController
                     }
 
                     // UIViewController
-                    if (rootViewController == nil) {
+                    if rootViewController == nil {
                         rootViewController = UIApplication.shared.keyWindow?.rootViewController
                     }
 
                     // ACQUIRE_ROOT_VIEW_CONTROLLER_FAILED
-                    if (rootViewController == nil) {
+                    if rootViewController == nil {
                         result(FlutterError.acquireRootViewControllerFailed)
                         return
                     }


### PR DESCRIPTION
This is a follow-up from https://github.com/LinusU/flutter_web_auth/pull/145.

I encountered this error again, and, after some research, I found that "As of iOS 13, `UIApplication.shared.delegate?.window` has been deprecated. Instead, you should use the `SceneDelegate` to get the root view controller. If you're targeting iOS 13 and later, you should update your code to handle this.". This attempts to address that (still testing)