### PR TITLE
[Android] Keep authentication on the same activity stack

### DIFF
--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -1,0 +1,85 @@
+package com.linusu.flutter_web_auth_2
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.browser.customtabs.CustomTabsIntent
+
+class AuthenticationManagementActivity(
+) : Activity() {
+    companion object {
+        const val KEY_AUTH_STARTED: String = "authStarted"
+        const val KEY_AUTH_URI: String = "authUri"
+        const val KEY_AUTH_OPTION_INTENT_FLAGS: String = "authOptionsIntentFlags"
+        const val KEY_AUTH_OPTION_TARGET_PACKAGE: String = "authOptionsTargetPackage"
+
+        fun createResponseHandlingIntent(context: Context): Intent {
+            val intent = Intent(context, AuthenticationManagementActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            return intent
+        }
+    }
+    private var authStarted: Boolean = false
+    private lateinit var authenticationUri: Uri
+    private var intentFlags: Int = 0
+    private var targetPackage: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            extractState(intent.extras)
+        } else {
+            extractState(savedInstanceState)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        if (!authStarted) {
+            val intent = CustomTabsIntent.Builder().build()
+            intent.intent.addFlags(intentFlags)
+
+            if (targetPackage != null) {
+                intent.intent.setPackage(targetPackage)
+            }
+            intent.launchUrl(this, authenticationUri)
+            authStarted = true
+            return
+        }
+        /* If the authentication was already started and we've returned here, the user either
+         * completed or cancelled authentication.
+         * Either way we want to return to our original flutter activity, so just finish here
+         */
+        finish()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        setIntent(intent);
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_AUTH_STARTED, authStarted)
+        outState.putParcelable(KEY_AUTH_URI, authenticationUri)
+        outState.putInt(KEY_AUTH_OPTION_INTENT_FLAGS, intentFlags)
+        outState.putString(
+            KEY_AUTH_OPTION_TARGET_PACKAGE,
+            targetPackage
+        )
+    }
+
+    private fun extractState(state: Bundle?) {
+        if (state == null) {
+            finish()
+            return
+        }
+        authStarted = state.getBoolean(KEY_AUTH_STARTED, false)
+        authenticationUri = state.getParcelable(KEY_AUTH_URI)!!
+        intentFlags = state.getInt(KEY_AUTH_OPTION_INTENT_FLAGS, 0)
+        targetPackage = state.getString(KEY_AUTH_OPTION_TARGET_PACKAGE)
+    }
+}

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/CallbackActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/CallbackActivity.kt
@@ -18,7 +18,8 @@ class CallbackActivity : Activity() {
         if (scheme != null) {
             FlutterWebAuth2Plugin.callbacks.remove(scheme)?.success(url.toString())
         }
-        finishAndRemoveTask()
+        startActivity(AuthenticationManagementActivity.createResponseHandlingIntent(this))
+        finish()
     }
 
 

--- a/flutter_web_auth_2/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_web_auth_2/example/android/app/src/main/AndroidManifest.xml
@@ -49,6 +49,8 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
+        <activity android:name="com.linusu.flutter_web_auth_2.AuthenticationManagementActivity">
+        </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/flutter_web_auth_2/lib/src/options.dart
+++ b/flutter_web_auth_2/lib/src/options.dart
@@ -1,12 +1,9 @@
 /// Default intent flags for opening the custom tabs intent on Android.
-/// This is essentially the same as
-/// `FLAG_ACTIVITY_SINGLE_TOP | FLAG_ACTIVITY_NEW_TASK`.
-const defaultIntentFlags = 1 << 29 | 1 << 28;
+const defaultIntentFlags = 0;
 
 /// "Ephemeral" intent flags for opening the custom tabs intent on Android.
 /// This is essentially the same as
-/// `FLAG_ACTIVITY_SINGLE_TOP | FLAG_ACTIVITY_NEW_TASK
-/// | FLAG_ACTIVITY_NO_HISTORY`.
+/// FLAG_ACTIVITY_NO_HISTORY`.
 const ephemeralIntentFlags = defaultIntentFlags | 1 << 30;
 
 /// Default HTML code that generates a nice callback page.


### PR DESCRIPTION
This PR changes the authentication process on Android, so that the chrome custom tab window opens on the same activity stack as the flutter application and no longer opens a new activity stack or window. This should improve end user experience as it is no longer possible for users that leave the application, to copy a 2FA code for example, to return to the wrong "window"

This all is achieved by starting a new activity (in this case `AuthenticationManagementActivity`) before starting the chrome custom tab. The `CallbackActivity` will then start the `AuthenticationManagementActivity` which will then finish and return to the original flutter activity.

**Breaking changes**
Applications must register a new activity:
```xml
<activity android:name="com.linusu.flutter_web_auth_2.AuthenticationManagementActivity">
</activity>
```