### PR TITLE
Add cancel method for iOS

### DIFF
--- a/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -157,9 +157,13 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
     private func cancel() {
         if let session = self.sessionToKeepAlive {
             if #available(iOS 12, *) {
-                (session as! ASWebAuthenticationSession).cancel()
+                if let webAuthSession = session as? ASWebAuthenticationSession {
+                    webAuthSession.cancel()
+                }
             } else if #available(iOS 11, *) {
-                (session as! SFAuthenticationSession).cancel()
+                if let authSession = session as? SFAuthenticationSession {
+                    authSession.cancel()
+                }
             }
             self.sessionToKeepAlive = nil
         }

--- a/flutter_web_auth_2/lib/flutter_web_auth_2.dart
+++ b/flutter_web_auth_2/lib/flutter_web_auth_2.dart
@@ -28,11 +28,15 @@ class _OnAppLifecycleResumeObserver extends WidgetsBindingObserver {
 class FlutterWebAuth2 {
   static final RegExp _schemeRegExp = RegExp(r'^[a-z][a-z\d+.-]*$');
 
-  static FlutterWebAuth2Platform get _platform =>
-      FlutterWebAuth2Platform.instance;
+  static FlutterWebAuth2Platform get _platform => FlutterWebAuth2Platform.instance;
 
   static final _OnAppLifecycleResumeObserver _resumedObserver =
       _OnAppLifecycleResumeObserver(_cleanUpDanglingCalls);
+
+  /// Cancels authontication session on iOS.
+  static Future<void> cancel() async {
+    await _platform.cancel();
+  }
 
   static void _assertCallbackScheme(String callbackUrlScheme) {
     if ((PlatformIs.web || (!PlatformIs.windows && !PlatformIs.linux)) &&

--- a/flutter_web_auth_2/lib/flutter_web_auth_2.dart
+++ b/flutter_web_auth_2/lib/flutter_web_auth_2.dart
@@ -33,7 +33,7 @@ class FlutterWebAuth2 {
   static final _OnAppLifecycleResumeObserver _resumedObserver =
       _OnAppLifecycleResumeObserver(_cleanUpDanglingCalls);
 
-  /// Cancels authontication session on iOS.
+  /// Cancels the currently open authentication session on iOS.
   static Future<void> cancel() async {
     await _platform.cancel();
   }

--- a/flutter_web_auth_2_platform_interface/lib/flutter_web_auth_2_platform_interface.dart
+++ b/flutter_web_auth_2_platform_interface/lib/flutter_web_auth_2_platform_interface.dart
@@ -56,6 +56,6 @@ abstract class FlutterWebAuth2Platform extends PlatformInterface {
   /// terminate all `authenticate` calls with an error.
   Future clearAllDanglingCalls() => _instance.clearAllDanglingCalls();
 
-  /// Dismisses the currently open authentication session on iOS.
+  /// Cancels the currently open authentication session on iOS.
   Future<void> cancel() => throw UnimplementedError('Only supported on iOS at the moment.');
 }

--- a/flutter_web_auth_2_platform_interface/lib/flutter_web_auth_2_platform_interface.dart
+++ b/flutter_web_auth_2_platform_interface/lib/flutter_web_auth_2_platform_interface.dart
@@ -55,4 +55,7 @@ abstract class FlutterWebAuth2Platform extends PlatformInterface {
   /// comes the callback will dangle around forever. This can be called to
   /// terminate all `authenticate` calls with an error.
   Future clearAllDanglingCalls() => _instance.clearAllDanglingCalls();
+
+  /// Dismisses the currently open authentication session on iOS.
+  Future<void> cancel() => throw UnimplementedError('Only supported on iOS at the moment.');
 }

--- a/flutter_web_auth_2_platform_interface/lib/method_channel/method_channel.dart
+++ b/flutter_web_auth_2_platform_interface/lib/method_channel/method_channel.dart
@@ -19,6 +19,8 @@ class FlutterWebAuth2MethodChannel extends FlutterWebAuth2Platform {
       '';
 
   @override
-  Future clearAllDanglingCalls() async =>
-      _channel.invokeMethod('cleanUpDanglingCalls');
+  Future clearAllDanglingCalls() async => _channel.invokeMethod('cleanUpDanglingCalls');
+
+  @override
+  Future<void> cancel() => _channel.invokeMethod('cancel');
 }


### PR DESCRIPTION
The registration flow we have sends an email to verify the user which in the successful case opens the app via deeplink.

It looks like in such cases it would be useful to have a way to cancel / hide the currently opened session.

