### PR TITLE
Fix ephemeral intent flags on Android

### DIFF
--- a/flutter_web_auth_2/README.md
+++ b/flutter_web_auth_2/README.md
@@ -80,7 +80,9 @@ final response = await http.post(url, body: {
 final accessToken = jsonDecode(response.body)['access_token'] as String;
 ```
 
-**Note:** To use multiple scopes with Google, you need to encode them as a single string, separated by spaces (`%20`). For example, `scope: 'email https://www.googleapis.com/auth/userinfo.profile'`. Here is [a list of all supported scopes](https://developers.google.com/identity/protocols/oauth2/scopes).
+**Note (Google multiple scopes):** To use multiple scopes with Google, you need to encode them as a single string, separated by spaces (`%20`). For example, `scope: 'email https://www.googleapis.com/auth/userinfo.profile'`. Here is [a list of all supported scopes](https://developers.google.com/identity/protocols/oauth2/scopes).
+
+**Note (ephemeral auth):** Due to a [knownw Chrome bug](https://issuetracker.google.com/issues/444173718), when setting `preferEphemeral: true` on Android, the webview will crash on older Chrome version (minimum version required is [Chrome 141](https://developer.chrome.com/release-notes/141?hl=en)).
 
 ## Migration
 

--- a/flutter_web_auth_2/android/build.gradle
+++ b/flutter_web_auth_2/android/build.gradle
@@ -49,7 +49,7 @@ android {
     }
 
     dependencies {
-        implementation 'androidx.browser:browser:1.9.0-alpha01'
+        implementation 'androidx.browser:browser:1.9.0'
         implementation 'androidx.activity:activity-ktx:1.10.1'
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     }

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -94,12 +94,6 @@ class AuthenticationManagementActivity : ComponentActivity() {
 
             val intent = intentBuilder.build()
 
-            // Manually set ephemeral extra in case builder didn't set it properly
-            if (preferEphemeral) {
-                intent.intent.putExtra("androidx.browser.customtabs.extra.ENABLE_EPHEMERAL_BROWSING", true)
-                Log.d("flutter_web_auth_2", "Manually set EXTRA_ENABLE_EPHEMERAL_BROWSING")
-            }
-
             intent.intent.addFlags(intentFlags)
 
             if (targetPackage != null) {

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -93,6 +93,13 @@ class AuthenticationManagementActivity : ComponentActivity() {
             }
 
             val intent = intentBuilder.build()
+
+            // Manually set ephemeral extra in case builder didn't set it properly
+            if (preferEphemeral) {
+                intent.intent.putExtra("androidx.browser.customtabs.extra.ENABLE_EPHEMERAL_BROWSING", true)
+                Log.d("flutter_web_auth_2", "Manually set EXTRA_ENABLE_EPHEMERAL_BROWSING")
+            }
+
             intent.intent.addFlags(intentFlags)
 
             if (targetPackage != null) {

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/FlutterWebAuth2Plugin.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/FlutterWebAuth2Plugin.kt
@@ -56,6 +56,7 @@ class FlutterWebAuth2Plugin(
                     putExtra(AuthenticationManagementActivity.KEY_AUTH_CALLBACK_SCHEME, callbackUrlScheme)
                     putExtra(AuthenticationManagementActivity.KEY_AUTH_CALLBACK_HOST, options["httpsHost"] as String?)
                     putExtra(AuthenticationManagementActivity.KEY_AUTH_CALLBACK_PATH, options["httpsPath"] as String?)
+                    putExtra(AuthenticationManagementActivity.KEY_AUTH_OPTION_PREFER_EPHEMERAL, options["preferEphemeral"] as Boolean? ?: false)
                 })
             }
 

--- a/flutter_web_auth_2/example/android/app/build.gradle
+++ b/flutter_web_auth_2/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.linusu.flutter_web_auth_2_example"
-        minSdk 21
+        minSdkVersion flutter.minSdkVersion
         targetSdk 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/flutter_web_auth_2/example/android/app/build.gradle
+++ b/flutter_web_auth_2/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.linusu.flutter_web_auth_2_example"
-        minSdkVersion flutter.minSdkVersion
+        minSdk 21
         targetSdk 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/flutter_web_auth_2/lib/src/options.dart
+++ b/flutter_web_auth_2/lib/src/options.dart
@@ -85,10 +85,10 @@ class FlutterWebAuth2Options {
           customTabsPackageOrder: json['customTabsPackageOrder'],
         );
 
-  /// **Only has an effect on iOS and macOS!**
+  /// **Only has an effect on iOS, Android and macOS!**
   /// If this is `true`, an ephemeral web browser session
   /// will be used where possible (`prefersEphemeralWebBrowserSession`).
-  /// For Android devices, see [intentFlags].
+  /// For Android devices (for supporting older Chrome than 141) alternatively you can see [intentFlags].
   final bool preferEphemeral;
 
   /// **Only has an effect on Web!**


### PR DESCRIPTION
Fixes issue #169 where `ephemeralIntentFlags` and `preferEphemeral: true` do not prevent user credentials from being remembered on Android.

 - Update androidx.browser dependency from 1.9.0-alpha01 to stable 1.9.0
 - Implement `setEphemeralBrowsingEnabled()` method with safe error handling
 - Add proper `preferEphemeral` option handling in AuthTab intent configuration
 - Ensure credentials are not remembered when ephemeral browsing is requested

 Closes (I think) #169