### PR TITLE
fix(android): handle null resultUri in handleAuthResult

### DIFF
--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -65,7 +65,12 @@ class AuthenticationManagementActivity : ComponentActivity() {
 
         when (result.resultCode) {
             AuthTabIntent.RESULT_OK -> {
-                callback.success(result.resultUri!!.toString())
+                val uri = result.resultUri
+                if (uri != null) {
+                    callback.success(uri.toString())
+                } else {
+                    callback.error("FAILED", "Authentication returned no URI", null)
+                }
             }
 
             AuthTabIntent.RESULT_CANCELED -> {


### PR DESCRIPTION
## Summary

Fixes a `NullPointerException` crash in `AuthenticationManagementActivity.handleAuthResult` when `result.resultUri` is null.

The current code uses `result.resultUri!!` (line 68), which crashes when the browser returns `data=null`. This can happen when:
- The user cancels authentication but the result code is still `RESULT_OK`
- The browser closes unexpectedly without returning a URI

### Before (crashes)
```kotlin
AuthTabIntent.RESULT_OK -> {
    callback.success(result.resultUri!!.toString())
}
```

### After (null-safe)
```kotlin
AuthTabIntent.RESULT_OK -> {
    val uri = result.resultUri
    if (uri != null) {
        callback.success(uri.toString())
    } else {
        callback.error("FAILED", "Authentication returned no URI", null)
    }
}
```

## Crash trace from Firebase Crashlytics

```
Fatal Exception: java.lang.RuntimeException
Failure delivering result ResultInfo{who=null, request=1227713562, result=-1, data=null}
  to activity {.../com.linusu.flutter_web_auth_2.AuthenticationManagementActivity}:
  java.lang.NullPointerException

Caused by java.lang.NullPointerException
  AuthenticationManagementActivity.handleAuthResult (AuthenticationManagementActivity.kt:68)
```

## Test plan

- [ ] Verify normal OAuth flow still works (resultUri is present)
- [ ] Verify cancellation returns CANCELED error to Flutter
- [ ] Verify null resultUri with RESULT_OK returns FAILED error instead of crash