### PR TITLE
Enhancement: provide detailed error information in FlutterError responses for iOS and macOS

### DIFF
--- a/flutter_web_auth_2/README.md
+++ b/flutter_web_auth_2/README.md
@@ -183,17 +183,34 @@ In order to capture the callback url, the following `activity` needs to be added
 
 If you are using `http` or `https` as your callback scheme, you also need to specify a host etc.
 See [c:geo](https://github.com/cgeo/cgeo/blob/d7ab67629ac4798adaae194e563afe7df134fcd0/main/AndroidManifest.xml#L164) as an example for this.
+To learn more about setting up Android App Links, see [Flutter's guide](https://docs.flutter.dev/cookbook/navigation/set-up-app-links).
 
-### iOS
+### iOS / macOS (Apple platforms)
 
-For "normal" authentication, just use this library as usual; there is nothing special to do!
+For custom callback schemes (for example `myapp://callback`), just use this library as usual.
 
-To authenticate using [Universal Links](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html)
-on iOS, use `https` as the provided `callbackUrlScheme`:
+If you use `https` as `callbackUrlScheme` (Universal Links), additional Apple platform setup is required:
+
+1. Configure **Associated Domains** in your app entitlements.
+2. Add your domain using the `webcredentials` service type (for example: `webcredentials:example.com`).
+3. Host a valid `apple-app-site-association` (AASA) file for that domain, with your app identifier.
+4. Pass `httpsHost` and `httpsPath` in `FlutterWebAuth2Options`.
+
+Example:
 
 ```dart
-final result = await FlutterWebAuth2.authenticate(url: "https://my-custom-app.com/connect", callbackUrlScheme: "https");
+final result = await FlutterWebAuth2.authenticate(
+  url: "https://my-custom-app.com/connect",
+  callbackUrlScheme: "https",
+  options: const FlutterWebAuth2Options(
+    httpsHost: "my-custom-app.com",
+    httpsPath: "/oauth",
+  ),
+);
 ```
+
+If this setup is incomplete, Apple can reject the auth callback and you'll receive a `PlatformException` from native code. Check `PlatformException.details` (`domain`, `code`, `description`) for the exact reason.
+To learn more about setting up Universal Links, see [Flutter's guide](https://docs.flutter.dev/cookbook/navigation/set-up-universal-links).
 
 ### Web
 
@@ -342,6 +359,38 @@ When you use this package for the first time, you may experience some problems. 
 
     header("Location: validscheme://?data1=value1&data2=value2");
     ```
+
+### Troubleshooting Native Errors (iOS/macOS)
+
+On iOS and macOS, native authentication failures are forwarded as `PlatformException` values.
+Besides `code` and `message`, the `details` map contains:
+- `domain`
+- `code`
+- `description`
+
+This is especially useful for `https` callback issues on Apple platforms (for example, Associated Domains / `webcredentials` setup problems).
+
+```dart
+import 'package:flutter/services.dart';
+
+try {
+  final result = await FlutterWebAuth2.authenticate(
+    url: authUrl,
+    callbackUrlScheme: 'https',
+    options: const FlutterWebAuth2Options(
+      httpsHost: 'example.com',
+      httpsPath: '/oauth',
+    ),
+  );
+  // use result
+} on PlatformException catch (e) {
+  final details = e.details is Map ? e.details as Map : const {};
+  final nativeDomain = details['domain'];
+  final nativeCode = details['code'];
+  final nativeDescription = details['description'];
+  // Log or show the native diagnostics here.
+}
+```
 
 ### Troubleshooting HTML redirects
 

--- a/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -41,11 +41,7 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
                                 FlutterError(
                                     code: "CANCELED",
                                     message: "User canceled login",
-                                    details: [
-                                        "domain": (err as NSError).domain,
-                                        "code": (err as NSError).code,
-                                        "description": err.localizedDescription
-                                   ]
+                                    details: Self.errorDetails(from: err)
                                )
                             )
                             return
@@ -58,18 +54,20 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
                                 FlutterError(
                                     code: "CANCELED",
                                     message: "User canceled login",
-                                    details: [
-                                        "domain": (err as NSError).domain,
-                                        "code": (err as NSError).code,
-                                        "description": err.localizedDescription
-                                   ]
+                                    details: Self.errorDetails(from: err)
                                 )
                             )
                             return
                         }
                     }
 
-                    result(FlutterError(code: "EUNKNOWN", message: err.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "EUNKNOWN",
+                            message: err.localizedDescription,
+                            details: Self.errorDetails(from: err)
+                        )
+                    )
                     return
                 }
 
@@ -172,6 +170,15 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
             default: return false
         }
     }
+
+    private static func errorDetails(from err: Error) -> [String: Any] {
+        let nsError = err as NSError
+        return [
+            "domain": nsError.domain,
+            "code": nsError.code,
+            "description": err.localizedDescription
+        ]
+    }
 }
 
 @available(iOS 13, *)
@@ -187,10 +194,22 @@ fileprivate extension FlutterError {
     }
 
     static var invalidHttpsHostError: FlutterError {
-        return FlutterError(code: "INVALID_HTTPS_HOST_ERROR", message: "Failed to retrieve host for https scheme", details: nil)
+        return FlutterError(
+            code: "INVALID_HTTPS_HOST_ERROR",
+            message: "Failed to retrieve host for https scheme",
+            details: [
+                "description": "When callbackUrlScheme is https, options.httpsHost must be provided."
+            ]
+        )
     }
 
     static var invalidHttpsPathError: FlutterError {
-        return FlutterError(code: "INVALID_HTTPS_PATH_ERROR", message: "Failed to retrieve path for https scheme", details: nil)
+        return FlutterError(
+            code: "INVALID_HTTPS_PATH_ERROR",
+            message: "Failed to retrieve path for https scheme",
+            details: [
+                "description": "When callbackUrlScheme is https, options.httpsPath must be provided."
+            ]
+        )
     }
 }

--- a/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -171,11 +171,10 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
         }
     }
 
-    private static func errorDetails(from err: Error) -> [String: Any] {
-        let nsError = err as NSError
+    private static func errorDetails(from err: NSError) -> [String: Any] {
         return [
-            "domain": nsError.domain,
-            "code": nsError.code,
+            "domain": err.domain,
+            "code": err.code,
             "description": err.localizedDescription
         ]
     }

--- a/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -24,11 +24,23 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, ASWebAuthentication
 
                 if let err = err {
                     if case ASWebAuthenticationSessionError.canceledLogin = err {
-                        result(FlutterError(code: "CANCELED", message: "User canceled login", details: nil))
+                        result(
+                            FlutterError(
+                                code: "CANCELED",
+                                message: "User canceled login",
+                                details: Self.errorDetails(from: err)
+                            )
+                        )
                         return
                     }
 
-                    result(FlutterError(code: "EUNKNOWN", message: err.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "EUNKNOWN",
+                            message: err.localizedDescription,
+                            details: Self.errorDetails(from: err)
+                        )
+                    )
                     return
                 }
 
@@ -77,6 +89,15 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, ASWebAuthentication
         }
     }
 
+    private static func errorDetails(from err: Error) -> [String: Any] {
+        let nsError = err as NSError
+        return [
+            "domain": nsError.domain,
+            "code": nsError.code,
+            "description": err.localizedDescription
+        ]
+    }
+
     @available(macOS 10.15, *)
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return NSApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
@@ -85,10 +106,22 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, ASWebAuthentication
 
 fileprivate extension FlutterError {
     static var invalidHttpsHostError: FlutterError {
-        return FlutterError(code: "INVALID_HTTPS_HOST_ERROR", message: "Failed to retrieve host for https scheme", details: nil)
+        return FlutterError(
+            code: "INVALID_HTTPS_HOST_ERROR",
+            message: "Failed to retrieve host for https scheme",
+            details: [
+                "description": "When callbackUrlScheme is https, options.httpsHost must be provided."
+            ]
+        )
     }
 
     static var invalidHttpsPathError: FlutterError {
-        return FlutterError(code: "INVALID_HTTPS_PATH_ERROR", message: "Failed to retrieve path for https scheme", details: nil)
+        return FlutterError(
+            code: "INVALID_HTTPS_PATH_ERROR",
+            message: "Failed to retrieve path for https scheme",
+            details: [
+                "description": "When callbackUrlScheme is https, options.httpsPath must be provided."
+            ]
+        )
     }
 }

--- a/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -89,11 +89,10 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, ASWebAuthentication
         }
     }
 
-    private static func errorDetails(from err: Error) -> [String: Any] {
-        let nsError = err as NSError
+    private static func errorDetails(from err: NSError) -> [String: Any] {
         return [
-            "domain": nsError.domain,
-            "code": nsError.code,
+            "domain": err.domain,
+            "code": err.code,
             "description": err.localizedDescription
         ]
     }


### PR DESCRIPTION
## Problem

While using this plugin on macOS, starting the authentication flow resulted in no visible action and only the following exception being thrown:

```text
PlatformException(CANCELED, User canceled login, null, null)
```

This made it difficult to identify the actual issue since no meaningful error details were being propagated to the Flutter layer.

After debugging the plugin and adding native-side logs, I discovered that the issue was caused by missing **Associated Domains** capability configuration. Specifically, the app was not configured with the required `webcredentials` associated domain.

Although the root cause was ultimately a configuration issue on the application side, the problem was difficult to diagnose because:

- The plugin did not propagate the underlying native error details.
- The current documentation does not explicitly mention this requirement for macOS setups.

## Solution

This PR improves error propagation from the native macOS implementation to the Flutter layer.

Instead of returning a generic cancellation error, the plugin now forwards the detailed native error information, making configuration issues significantly easier to diagnose.

### Before

```text
PlatformException(CANCELED, User canceled login, null, null)
```

### After

```text
PlatformException(
  CANCELED,
  User canceled login,
  {
    description: The operation couldn’t be completed. Application with identifier ABCDEFG.com.example.test is not associated with domain example.com. Using HTTPS callbacks requires Associated Domains using the `webcredentials` service type for example.com,
    domain: com.apple.AuthenticationServices.WebAuthenticationSession,
    code: 1
  },
  null
)
```

## Benefits

- Improves debugging experience for macOS authentication issues.
- Exposes actionable native error details to Flutter developers.
- Makes missing Associated Domains configuration immediately identifiable.
- Reduces time spent diagnosing silent authentication failures.