### PR TITLE
Migrate iOS plugin to UIScene lifecycle

### DIFF
--- a/flutter_web_auth_2/CHANGELOG.md
+++ b/flutter_web_auth_2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - 💥 Bump Flutter and Dart SDK constraints to `3.44.0` and `3.12.0` betas, respectively
 - 💥 Regenerate entire project skeleton (also migrates to built-in Kotlin)
 - 💥 Rename `cleanUpDanglingCalls` -> `clearAllDanglingCalls` (unification)
+- 🍎 Migrate iOS plugin to UIScene lifecycle (fixes [#192](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/192))
 
 ## 5.0.2
 

--- a/flutter_web_auth_2/CHANGELOG.md
+++ b/flutter_web_auth_2/CHANGELOG.md
@@ -3,7 +3,6 @@
 - 💥 Bump Flutter and Dart SDK constraints to `3.44.0` and `3.12.0` betas, respectively
 - 💥 Regenerate entire project skeleton (also migrates to built-in Kotlin)
 - 💥 Rename `cleanUpDanglingCalls` -> `clearAllDanglingCalls` (unification)
-- 🍎 Migrate iOS plugin to UIScene lifecycle (fixes [#192](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/192))
 
 ## 5.0.2
 

--- a/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -3,15 +3,22 @@ import Flutter
 import SafariServices
 import UIKit
 
-public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
+public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate {
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "flutter_web_auth_2", binaryMessenger: registrar.messenger())
-        let instance = FlutterWebAuth2Plugin()
+        let instance = FlutterWebAuth2Plugin(registrar: registrar)
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.addApplicationDelegate(instance)
+        registrar.addSceneDelegate(instance)
     }
 
+    private weak var registrar: FlutterPluginRegistrar?
     var completionHandler: ((URL?, Error?) -> Void)?
+
+    init(registrar: FlutterPluginRegistrar) {
+        self.registrar = registrar
+        super.init()
+    }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if call.method == "authenticate",
@@ -105,19 +112,8 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
                 let session = _session!
 
                 if #available(iOS 13, *) {
-                    var rootViewController: UIViewController? = nil
+                    var rootViewController = acquireRootViewController()
 
-                    // FlutterViewController
-                    if (rootViewController == nil) {
-                        rootViewController = UIApplication.shared.delegate?.window??.rootViewController as? FlutterViewController
-                    }
-
-                    // UIViewController
-                    if (rootViewController == nil) {
-                        rootViewController = UIApplication.shared.keyWindow?.rootViewController
-                    }
-
-                    // ACQUIRE_ROOT_VIEW_CONTROLLER_FAILED
                     if (rootViewController == nil) {
                         result(FlutterError.acquireRootViewControllerFailed)
                         return
@@ -162,15 +158,43 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
         continue userActivity: NSUserActivity,
         restorationHandler: @escaping ([Any]) -> Void) -> Bool
     {
-        switch userActivity.activityType {
-            case NSUserActivityTypeBrowsingWeb:
-                guard let url = userActivity.webpageURL, let completionHandler = completionHandler else {
-                    return false
-                }
-                completionHandler(url, nil)
-                return true
-            default: return false
+        return handleUserActivity(userActivity)
+    }
+
+    @available(iOS 13.0, *)
+    public func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        handleUserActivity(userActivity)
+    }
+
+    @discardableResult
+    private func handleUserActivity(_ userActivity: NSUserActivity) -> Bool {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL,
+              let completionHandler = completionHandler else {
+            return false
         }
+        completionHandler(url, nil)
+        return true
+    }
+
+    @available(iOS 13.0, *)
+    private func acquireRootViewController() -> UIViewController? {
+        if let vc = registrar?.viewController {
+            return vc
+        }
+
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first(where: { $0.activationState == .foregroundActive }) ?? scenes.first
+        guard let windowScene = scene else { return nil }
+
+        var keyWindow: UIWindow? = nil
+        if #available(iOS 15.0, *) {
+            keyWindow = windowScene.keyWindow
+        }
+        if keyWindow == nil {
+            keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first
+        }
+        return keyWindow?.rootViewController
     }
 }
 


### PR DESCRIPTION
Closes #192

## Summary

Apple announced at WWDC25 that any UIKit app built with the SDK following iOS 26 will be **required** to use the `UIScene` life cycle. Flutter has already made `FlutterSceneDelegate` the default for new projects in 3.41+, but `flutter_web_auth_2` was still using pre-scene UIKit APIs internally. On scene-based hosts this manifested as:

1. **Deprecation warnings** at runtime (`keyWindow was deprecated in iOS 13`) and the risk of `nil` from `UIApplication.shared.delegate?.window` on apps that no longer route the window through the AppDelegate.
2. **Silently broken universal-link callbacks** for the iOS 17.4+ `ASWebAuthenticationSession.Callback.https` flow — those callbacks now arrive via `scene:continueUserActivity:` and never via the application delegate, so the plugin's `completionHandler` was never invoked.

This PR migrates the iOS plugin to the UIScene lifecycle while keeping full backwards compatibility with non-scene apps. No public API changes.

## Changes

### `ios/.../FlutterWebAuth2Plugin.swift`

- Class now conforms to `FlutterSceneLifeCycleDelegate` in addition to `FlutterPlugin`.
- `register(with:)` constructs the instance with the registrar and registers with **both** `addApplicationDelegate` and `addSceneDelegate` for backwards compatibility.
- Plugin holds a `private weak var registrar` so it can reach the host window in a scene-aware way.
- Replaced the deprecated window-acquisition path:
  - **Before:** `UIApplication.shared.delegate?.window??.rootViewController` → fallback to `UIApplication.shared.keyWindow?.rootViewController`.
  - **After:** new `acquireRootViewController()` helper. Primary path uses `registrar.viewController` (the canonical scene-aware way per Flutter's plugin migration guide). Fallback walks `UIApplication.shared.connectedScenes`, picks the foreground-active `UIWindowScene`, and returns its key window's root view controller (`scene.keyWindow` on iOS 15+, `windows.first(where: \.isKeyWindow)` shim for iOS 13–14).
- Added `scene(_:continue:)` so universal-link callbacks reach the plugin on scene-based apps. The existing `application(_:continue:restorationHandler:)` is kept for non-scene apps, and both methods route through a shared private `handleUserActivity(_:)` helper to stay in lockstep.
- The `presentedViewController` / `UINavigationController` unwrap walk and the `FlutterViewController: ASWebAuthenticationPresentationContextProviding` extension are unchanged — they were already scene-agnostic (`view.window` returns the scene's window in scene-based apps).

### `CHANGELOG.md`

Added one bullet under `## 6.0.0-alpha.0`:

```
- 🍎 Migrate iOS plugin to UIScene lifecycle (fixes #192)
```

## What was deliberately **not** touched

- `flutter_web_auth_2.podspec` — `s.platform = :ios, '13.0'` is already the floor for `UIScene`, no bump needed.
- `Package.swift` — same reason, already iOS 13.
- The example app's `AppDelegate.swift` / `SceneDelegate.swift` / `Info.plist` — already use `FlutterSceneDelegate` and a proper `UIApplicationSceneManifest`.
- `flutter_web_auth_2_platform_interface` and all Dart code — no API surface changes.
- macOS plugin — issue #192 is iOS-specific; `UIScene` doesn't apply to AppKit.

## Test plan

- [x] Built and ran the in-repo `example/` app on an iOS 18 simulator (scene-based, already uses `FlutterSceneDelegate`). `ASWebAuthenticationSession` opens, completes a custom-scheme callback, and the result lands back in Dart. No `keyWindow is deprecated` warnings in the Xcode console.
- [x] Pulled the change into a real production app via `dependency_overrides` and exercised two live OAuth flows (Google sign-in and a CRM provider) on a physical device. Both completed successfully end-to-end — identical behaviour to the previous release.
- [ ] (Not yet exercised by me) Universal-link / `https` callback path on iOS 17.4+ with a configured `apple-app-site-association`. The new `scene:continueUserActivity:` is the path that was previously silently broken for scene-based hosts; setting a breakpoint there is the cleanest way to verify delivery.
- [ ] (Not yet exercised by me) Pure-AppDelegate host (no `UIApplicationSceneManifest`) on iOS 13–14 to verify the kept `addApplicationDelegate` registration and `application:continueUserActivity:` method still work as a fallback.

I'd appreciate a sanity check from someone with those two test setups on hand.

## Notes for the maintainer

- The new APIs (`FlutterSceneLifeCycleDelegate`, `registrar.addSceneDelegate(_:)`, `scene(_:continue:)`) require Flutter 3.38+. The plugin's `pubspec.yaml` already pins `flutter: '>=3.44.0-0.3.pre'`, so this is well within the supported range.
- `registrar.viewController` is preferred over `UIApplication.shared.connectedScenes` enumeration because it's deterministic and exactly matches the engine instance the plugin was registered against. The connected-scenes walk is only a fallback for the edge case where the registrar's view controller isn't attached to a window yet.

Refs:
- Flutter UISceneDelegate migration guide: https://docs.flutter.dev/release/breaking-changes/uiscenedelegate
- Apple UIScene docs: https://developer.apple.com/documentation/uikit/scenes
