### PR TITLE
Internalize desktop window activation and fix webview callback handling

### DIFF
--- a/flutter_web_auth_2/example/linux/flutter/generated_plugin_registrant.cc
+++ b/flutter_web_auth_2/example/linux/flutter/generated_plugin_registrant.cc
@@ -7,17 +7,17 @@
 #include "generated_plugin_registrant.h"
 
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
+#include <flutter_web_auth_2/flutter_web_auth2_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
-#include <window_to_front/window_to_front_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) desktop_webview_window_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWebviewWindowPlugin");
   desktop_webview_window_plugin_register_with_registrar(desktop_webview_window_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_web_auth_2_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterWebAuth2Plugin");
+  flutter_web_auth2_plugin_register_with_registrar(flutter_web_auth_2_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
-  g_autoptr(FlPluginRegistrar) window_to_front_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowToFrontPlugin");
-  window_to_front_plugin_register_with_registrar(window_to_front_registrar);
 }

--- a/flutter_web_auth_2/example/linux/flutter/generated_plugins.cmake
+++ b/flutter_web_auth_2/example/linux/flutter/generated_plugins.cmake
@@ -4,8 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
+  flutter_web_auth_2
   url_launcher_linux
-  window_to_front
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/flutter_web_auth_2/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_web_auth_2/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,11 +8,9 @@ import Foundation
 import desktop_webview_window
 import flutter_web_auth_2
 import url_launcher_macos
-import window_to_front
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopWebviewWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWebviewWindowPlugin"))
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
-  WindowToFrontPlugin.register(with: registry.registrar(forPlugin: "WindowToFrontPlugin"))
 }

--- a/flutter_web_auth_2/example/pubspec.yaml
+++ b/flutter_web_auth_2/example/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   cupertino_icons: ^1.0.8
-  desktop_webview_window: ^0.2.3
+  desktop_webview_window: ^0.3.0
   flutter:
     sdk: flutter
   flutter_web_auth_2: ^6.0.0-alpha.0

--- a/flutter_web_auth_2/example/windows/flutter/generated_plugin_registrant.cc
+++ b/flutter_web_auth_2/example/windows/flutter/generated_plugin_registrant.cc
@@ -7,14 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <desktop_webview_window/desktop_webview_window_plugin.h>
+#include <flutter_web_auth_2/flutter_web_auth2_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
-#include <window_to_front/window_to_front_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   DesktopWebviewWindowPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWebviewWindowPlugin"));
+  FlutterWebAuth2PluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterWebAuth2Plugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
-  WindowToFrontPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("WindowToFrontPlugin"));
 }

--- a/flutter_web_auth_2/example/windows/flutter/generated_plugins.cmake
+++ b/flutter_web_auth_2/example/windows/flutter/generated_plugins.cmake
@@ -4,8 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_webview_window
+  flutter_web_auth_2
   url_launcher_windows
-  window_to_front
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/flutter_web_auth_2/lib/src/server.dart
+++ b/flutter_web_auth_2/lib/src/server.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:flutter_web_auth_2_platform_interface/flutter_web_auth_2_platform_interface.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:window_to_front/window_to_front.dart';
+import 'package:flutter_web_auth_2/src/window_to_front.dart';
 
 /// Implements the plugin interface using an internal server (currently used by
 /// Windows and Linux).

--- a/flutter_web_auth_2/lib/src/webview.dart
+++ b/flutter_web_auth_2/lib/src/webview.dart
@@ -39,14 +39,14 @@ class FlutterWebAuth2WebViewPlugin extends FlutterWebAuth2Platform {
         userDataFolderWindows: (await getTemporaryDirectory()).path,
       ),
     );
-    _webview!.addOnUrlRequestCallback((url) {
+    _webview!.setOnUrlRequestCallback((url) {
       final uri = Uri.parse(url);
       if (uri.scheme != callbackUrlScheme ||
           (parsedOptions.httpsHost != null &&
               uri.host != parsedOptions.httpsHost) ||
           (parsedOptions.httpsPath != null &&
               uri.path != parsedOptions.httpsPath)) {
-        return;
+        return true;
       }
       _authenticated = true;
       _webview?.close();
@@ -56,6 +56,7 @@ class FlutterWebAuth2WebViewPlugin extends FlutterWebAuth2Platform {
        */
       _webview = null;
       c.complete(url);
+      return false;
     });
     unawaited(
       _webview!.onClose.whenComplete(() {

--- a/flutter_web_auth_2/lib/src/window_to_front.dart
+++ b/flutter_web_auth_2/lib/src/window_to_front.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/services.dart';
+
+class WindowToFront {
+  static const MethodChannel _channel = MethodChannel('flutter_web_auth_2');
+
+  static Future<void> activate() async {
+    try {
+      await _channel.invokeMethod<void>('activate');
+    } on MissingPluginException {
+      // Best-effort on desktop; ignore if not implemented.
+    } on PlatformException {
+      // Best-effort on desktop; ignore if activation fails.
+    }
+  }
+}

--- a/flutter_web_auth_2/linux/CMakeLists.txt
+++ b/flutter_web_auth_2/linux/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+set(PROJECT_NAME "flutter_web_auth_2")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed
+set(PLUGIN_NAME "flutter_web_auth_2_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "flutter_web_auth_2_plugin.cc"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+# List of absolute paths to libraries that should be bundled with the plugin
+set(flutter_web_auth_2_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/flutter_web_auth_2/linux/flutter_web_auth_2_plugin.cc
+++ b/flutter_web_auth_2/linux/flutter_web_auth_2_plugin.cc
@@ -1,0 +1,76 @@
+#include "include/flutter_web_auth_2/flutter_web_auth_2_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+
+#include <string.h>
+
+#define FLUTTER_WEB_AUTH_2_PLUGIN(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), flutter_web_auth_2_plugin_get_type(), \
+                              FlutterWebAuth2Plugin))
+
+struct _FlutterWebAuth2Plugin {
+  GObject parent_instance;
+
+  FlPluginRegistrar* registrar;
+};
+
+G_DEFINE_TYPE(FlutterWebAuth2Plugin, flutter_web_auth_2_plugin, g_object_get_type())
+
+static void flutter_web_auth_2_plugin_handle_method_call(
+    FlutterWebAuth2Plugin* self,
+    FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "activate") == 0) {
+    FlView* view = fl_plugin_registrar_get_view(self->registrar);
+    if (view != nullptr) {
+      GtkWidget* toplevel = gtk_widget_get_toplevel(GTK_WIDGET(view));
+      if (GTK_IS_WINDOW(toplevel)) {
+        gtk_window_present(GTK_WINDOW(toplevel));
+      }
+    }
+
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void flutter_web_auth_2_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(flutter_web_auth_2_plugin_parent_class)->dispose(object);
+}
+
+static void flutter_web_auth_2_plugin_class_init(FlutterWebAuth2PluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = flutter_web_auth_2_plugin_dispose;
+}
+
+static void flutter_web_auth_2_plugin_init(FlutterWebAuth2Plugin* self) {}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  FlutterWebAuth2Plugin* plugin = FLUTTER_WEB_AUTH_2_PLUGIN(user_data);
+  flutter_web_auth_2_plugin_handle_method_call(plugin, method_call);
+}
+
+void flutter_web_auth_2_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  FlutterWebAuth2Plugin* plugin = FLUTTER_WEB_AUTH_2_PLUGIN(
+      g_object_new(flutter_web_auth_2_plugin_get_type(), nullptr));
+
+  plugin->registrar = FL_PLUGIN_REGISTRAR(g_object_ref(registrar));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel =
+      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
+                            "flutter_web_auth_2",
+                            FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(channel, method_call_cb,
+                                            g_object_ref(plugin),
+                                            g_object_unref);
+
+  g_object_unref(plugin);
+}

--- a/flutter_web_auth_2/linux/include/flutter_web_auth_2/flutter_web_auth_2_plugin.h
+++ b/flutter_web_auth_2/linux/include/flutter_web_auth_2/flutter_web_auth_2_plugin.h
@@ -1,0 +1,26 @@
+#ifndef FLUTTER_PLUGIN_FLUTTER_WEB_AUTH_2_PLUGIN_H_
+#define FLUTTER_PLUGIN_FLUTTER_WEB_AUTH_2_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __attribute__((visibility("default")))
+#else
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+typedef struct _FlutterWebAuth2Plugin FlutterWebAuth2Plugin;
+typedef struct {
+  GObjectClass parent_class;
+} FlutterWebAuth2PluginClass;
+
+FLUTTER_PLUGIN_EXPORT GType flutter_web_auth_2_plugin_get_type();
+
+FLUTTER_PLUGIN_EXPORT void flutter_web_auth_2_plugin_register_with_registrar(
+    FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_FLUTTER_WEB_AUTH_2_PLUGIN_H_

--- a/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import Cocoa
 import SafariServices
 import FlutterMacOS
 
@@ -69,6 +70,9 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, ASWebAuthentication
 
             session.start()
             sessionToKeepAlive = session
+        } else if call.method == "activate" {
+            NSApplication.shared.activate(ignoringOtherApps: true)
+            result(nil)
         } else if call.method == "clearAllDanglingCalls" {
             // we do not keep track of old callbacks on macOS, so nothing to do here
             result(nil)

--- a/flutter_web_auth_2/pubspec.yaml
+++ b/flutter_web_auth_2/pubspec.yaml
@@ -25,7 +25,7 @@ environment:
   flutter: '>=3.44.0-0.3.pre'
 
 dependencies:
-  desktop_webview_window: ^0.2.3
+  desktop_webview_window: ^0.3.0
   flutter:
     sdk: flutter
   flutter_web_auth_2_platform_interface: ^6.0.0-alpha.0
@@ -34,7 +34,6 @@ dependencies:
   path_provider: ^2.1.2
   url_launcher: ^6.1.6
   web: ">=0.5.0 <2.0.0"
-  window_to_front: ^0.0.3
 
 dev_dependencies:
   flutter_lints: ^6.0.0
@@ -50,6 +49,7 @@ flutter:
       ios:
         pluginClass: FlutterWebAuth2Plugin
       linux:
+        pluginClass: FlutterWebAuth2Plugin
         dartPluginClass: FlutterWebAuth2LinowsPlugin
         fileName: src/linows.dart
       macos:
@@ -58,5 +58,6 @@ flutter:
         pluginClass: FlutterWebAuth2WebPlugin
         fileName: src/web.dart
       windows:
+        pluginClass: FlutterWebAuth2Plugin
         dartPluginClass: FlutterWebAuth2LinowsPlugin
         fileName: src/linows.dart

--- a/flutter_web_auth_2/windows/CMakeLists.txt
+++ b/flutter_web_auth_2/windows/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.15)
+set(PROJECT_NAME "flutter_web_auth_2")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+# This value is used when generating builds using this plugin, so it must
+# not be changed
+set(PLUGIN_NAME "flutter_web_auth_2_plugin")
+
+add_library(${PLUGIN_NAME} SHARED
+  "flutter_web_auth_2_plugin.cpp"
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES
+  CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+
+# List of absolute paths to libraries that should be bundled with the plugin
+set(flutter_web_auth_2_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/flutter_web_auth_2/windows/flutter_web_auth_2_plugin.cpp
+++ b/flutter_web_auth_2/windows/flutter_web_auth_2_plugin.cpp
@@ -1,0 +1,86 @@
+#include "include/flutter_web_auth_2/flutter_web_auth_2_plugin.h"
+
+// This must be included before many other Windows headers.
+#include <windows.h>
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+#include <flutter/standard_method_codec.h>
+
+#include <map>
+#include <memory>
+
+namespace {
+
+class FlutterWebAuth2Plugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows* registrar);
+
+  explicit FlutterWebAuth2Plugin(flutter::PluginRegistrarWindows* registrar);
+
+  ~FlutterWebAuth2Plugin() override;
+
+ private:
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue>& method_call,
+      std::unique_ptr<flutter::MethodResult<>> result);
+
+  flutter::PluginRegistrarWindows* registrar_;
+};
+
+void FlutterWebAuth2Plugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows* registrar) {
+  auto channel = std::make_unique<flutter::MethodChannel<>>(
+      registrar->messenger(), "flutter_web_auth_2",
+      &flutter::StandardMethodCodec::GetInstance());
+
+  auto plugin = std::make_unique<FlutterWebAuth2Plugin>(registrar);
+
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto& call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+FlutterWebAuth2Plugin::FlutterWebAuth2Plugin(
+    flutter::PluginRegistrarWindows* registrar)
+    : registrar_(registrar) {}
+
+FlutterWebAuth2Plugin::~FlutterWebAuth2Plugin() {}
+
+void FlutterWebAuth2Plugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue>& method_call,
+    std::unique_ptr<flutter::MethodResult<>> result) {
+  if (method_call.method_name().compare("activate") == 0) {
+    // Raise the Flutter window to the foreground.
+    HWND window = registrar_->GetView()->GetNativeWindow();
+    if (window != nullptr) {
+      HWND current_window = ::GetForegroundWindow();
+      DWORD current_thread = ::GetWindowThreadProcessId(current_window, nullptr);
+      DWORD this_thread = ::GetCurrentThreadId();
+      ::AttachThreadInput(current_thread, this_thread, TRUE);
+      ::SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0,
+                     SWP_NOSIZE | SWP_NOMOVE);
+      ::SetWindowPos(window, HWND_NOTOPMOST, 0, 0, 0, 0,
+                     SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
+      ::SetForegroundWindow(window);
+      ::SetFocus(window);
+      ::SetActiveWindow(window);
+      ::AttachThreadInput(current_thread, this_thread, FALSE);
+    }
+    result->Success();
+  } else {
+    result->NotImplemented();
+  }
+}
+
+}  // namespace
+
+void FlutterWebAuth2PluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  FlutterWebAuth2Plugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}

--- a/flutter_web_auth_2/windows/include/flutter_web_auth_2/flutter_web_auth_2_plugin.h
+++ b/flutter_web_auth_2/windows/include/flutter_web_auth_2/flutter_web_auth_2_plugin.h
@@ -1,0 +1,23 @@
+#ifndef FLUTTER_PLUGIN_FLUTTER_WEB_AUTH_2_PLUGIN_H_
+#define FLUTTER_PLUGIN_FLUTTER_WEB_AUTH_2_PLUGIN_H_
+
+#include <flutter_plugin_registrar.h>
+
+#ifdef FLUTTER_PLUGIN_IMPL
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define FLUTTER_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void FlutterWebAuth2PluginRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // FLUTTER_PLUGIN_FLUTTER_WEB_AUTH_2_PLUGIN_H_


### PR DESCRIPTION
Summary: internalize desktop window activation, add native activation handlers, refresh generated registrants/example deps, and fix URL request callback handling in the desktop webview flow.

fix: #202 