### PR TITLE
Fix: Cannot convert value of type 'any Error' to expected argument type 'NSError'

### DIFF
--- a/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -195,11 +195,12 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, FlutterSceneLifeCyc
         return keyWindow?.rootViewController
     }
 
-    private static func errorDetails(from err: NSError) -> [String: Any] {
+    private static func errorDetails(from err: Error) -> [String: Any] {
+        let nsError = err as NSError
         return [
-            "domain": err.domain,
-            "code": err.code,
-            "description": err.localizedDescription
+            "domain": nsError.domain,
+            "code": nsError.code,
+            "description": nsError.localizedDescription
         ]
     }
 }

--- a/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/macos/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift
@@ -89,11 +89,12 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin, ASWebAuthentication
         }
     }
 
-    private static func errorDetails(from err: NSError) -> [String: Any] {
+    private static func errorDetails(from err: Error) -> [String: Any] {
+        let nsError = err as NSError
         return [
-            "domain": err.domain,
-            "code": err.code,
-            "description": err.localizedDescription
+            "domain": nsError.domain,
+            "code": nsError.code,
+            "description": nsError.localizedDescription
         ]
     }
 


### PR DESCRIPTION
### Issue:

This PR fixes a bug introduced by PR https://github.com/ThexXTURBOXx/flutter_web_auth_2/pull/200 https://github.com/ThexXTURBOXx/flutter_web_auth_2/pull/200/changes/3bcf5cd972dafce3ad46879884fbc361a6a42318.

```
Swift Compiler Error (Xcode): Cannot convert value of type 'any Error' to expected argument type 'NSError'
/Users/abhi/.pub-cache/hosted/pub.dev/flutter_web_auth_2-6.0.0-alpha.2/ios/flutter_web_auth_2/Sources/flutter_web_auth_2/FlutterWebAuth2Plugin.swift:50:69
```

It appears that you can unconditionally typecast a Swift `Error` to `NSError` because Swift features built-in toll-free bridging for errors, meaning the runtime automatically boxes the Swift error into an `NSError` object.
https://stackoverflow.com/questions/51602907/why-can-any-error-be-unconditionally-converted-to-nserror

PS: Sorry, for not catching this issue earlier. It passed during by testing but it was a because of a cached version. 