### PR TITLE
fix(android): handle missing authUri/callbackScheme in AuthenticationManagementActivity gracefully

### DIFF
--- a/flutter_web_auth_2/CHANGELOG.md
+++ b/flutter_web_auth_2/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-- 🐛 Fix `AuthenticationManagementActivity` crash (`IllegalStateException: Authentication URI is null`) when the activity is recreated from an incomplete saved state after the app's process was killed during external browser authentication ([#207](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/207))
-
 ## 6.0.0-alpha.5
 
 - 🌹 Allow `window_to_front` versions `1.x`

--- a/flutter_web_auth_2/CHANGELOG.md
+++ b/flutter_web_auth_2/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- 🐛 Fix `AuthenticationManagementActivity` crash (`IllegalStateException: Authentication URI is null`) when the activity is recreated from an incomplete saved state after the app's process was killed during external browser authentication ([#207](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/207))
+
 ## 6.0.0-alpha.5
 
 - 🌹 Allow `window_to_front` versions `1.x`

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -211,11 +211,11 @@ class AuthenticationManagementActivity : ComponentActivity() {
             Log.e(
                 LOG_TAG,
                 "Unable to restore authentication state (missing authUri and/or " +
-                    "callbackScheme), likely due to process death. Finishing gracefully."
+                    "callbackScheme), likely due to process death. Finishing gracefully"
             )
             if (scheme != null) {
                 FlutterWebAuth2Plugin.callbacks[scheme]?.error(
-                    "FAILED",
+                    "CANNOT_RESTORE",
                     "Authentication session was lost, likely because the app was killed in the background. Please try again.",
                     null
                 )

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -33,6 +33,7 @@ class AuthenticationManagementActivity : ComponentActivity() {
     }
 
     private var authStarted: Boolean = false
+    private var hasValidState: Boolean = false
     private lateinit var authenticationUri: Uri
     private var intentFlags: Int = 0
     private var targetPackage: String? = null
@@ -88,6 +89,14 @@ class AuthenticationManagementActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
+
+        // If we couldn't restore a valid authentication state (e.g. the app process was
+        // killed while the user was completing authentication in an external browser),
+        // extractState() has already finished this activity. Bail out here instead of
+        // touching the not-yet-initialized fields below.
+        if (!hasValidState) {
+            return
+        }
 
         if (!authStarted) {
 
@@ -184,18 +193,46 @@ class AuthenticationManagementActivity : ComponentActivity() {
             finish()
             return
         }
-        authStarted = state.getBoolean(KEY_AUTH_STARTED, false)
-        authenticationUri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+
+        val scheme = state.getString(KEY_AUTH_CALLBACK_SCHEME)
+        val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             state.getParcelable(KEY_AUTH_URI, Uri::class.java)
         } else {
             @Suppress("deprecation")
             state.getParcelable(KEY_AUTH_URI)
-        } ?: throw IllegalStateException("Authentication URI is null")
+        }
+
+        if (uri == null || scheme == null) {
+            // This can happen when Android recreates this activity from an incomplete
+            // saved-state Bundle after the app's process was killed (e.g. low memory)
+            // while the user was completing authentication in an external browser.
+            // Finish gracefully instead of crashing the host app, and resolve any
+            // still-pending callback with an error so callers don't hang forever.
+            Log.e(
+                LOG_TAG,
+                "Unable to restore authentication state (missing authUri and/or " +
+                    "callbackScheme), likely due to process death. Finishing gracefully."
+            )
+            if (scheme != null) {
+                FlutterWebAuth2Plugin.callbacks[scheme]?.error(
+                    "FAILED",
+                    "Authentication session was lost, likely because the app was killed in the background. Please try again.",
+                    null
+                )
+                FlutterWebAuth2Plugin.callbacks.remove(scheme)
+            }
+            finish()
+            return
+        }
+
+        authStarted = state.getBoolean(KEY_AUTH_STARTED, false)
+        authenticationUri = uri
         intentFlags = state.getInt(KEY_AUTH_OPTION_INTENT_FLAGS, 0)
         targetPackage = state.getString(KEY_AUTH_OPTION_TARGET_PACKAGE)
         preferEphemeral = state.getBoolean(KEY_AUTH_OPTION_PREFER_EPHEMERAL, false)
-        callbackScheme = state.getString(KEY_AUTH_CALLBACK_SCHEME)!!
+        callbackScheme = scheme
         callbackHost = state.getString(KEY_AUTH_CALLBACK_HOST)
         callbackPath = state.getString(KEY_AUTH_CALLBACK_PATH)
+        hasValidState = true
     }
 }


### PR DESCRIPTION
## Description

Fixes #207.

`AuthenticationManagementActivity.extractState()` throws an uncaught `IllegalStateException: Authentication URI is null` and crashes the host app when the activity is recreated from a saved-state `Bundle` that doesn't contain a usable `authUri` parcelable (e.g. after the app's process was killed while the user was completing authentication in an external browser, and Android later recreates the activity from an incomplete saved state instead of reusing the original instance).

The `state == null` case is already handled gracefully (`finish()`), but the 'state is non-null but missing the URI (or callback scheme)' case previously threw instead of also finishing gracefully.

## Changes

- `extractState()` now reads `authUri` and `callbackScheme` first and, if either is missing, logs the situation, resolves any still-pending callback in `FlutterWebAuth2Plugin.callbacks` with an error (so Dart-side callers don't hang forever), and calls `finish()` — mirroring the existing null-`Bundle` handling instead of throwing.
- Added a `hasValidState` flag set only when state extraction succeeds, and guarded `onResume()` with it, so it can no longer touch the un-initialized `authenticationUri`/`callbackScheme` `lateinit` fields in this scenario.
- Added a CHANGELOG entry.

## Crash (from Crashlytics)

```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{<app-package>/com.linusu.flutter_web_auth_2.AuthenticationManagementActivity}
Caused by java.lang.IllegalStateException: Authentication URI is null
    at com.linusu.flutter_web_auth_2.AuthenticationManagementActivity.extractState(AuthenticationManagementActivity.kt:193)
    at com.linusu.flutter_web_auth_2.AuthenticationManagementActivity.onCreate(AuthenticationManagementActivity.kt:53)
```
