### PR TITLE
fix(android): catch SecurityException when launching the auth tab

### DIFF
--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -130,6 +130,16 @@ class AuthenticationManagementActivity : ComponentActivity() {
                 callback?.error("NO_BROWSER", "No valid browser available for authentication.", e.message)
                 FlutterWebAuth2Plugin.callbacks.remove(callbackScheme)
                 finish()
+            } catch (e: SecurityException) {
+                // Some apps register themselves as browsers but do not export their
+                // intent-handling activity; launching the tab then throws instead of
+                // ActivityNotFoundException. Fail the attempt like the no-browser case
+                // rather than crashing the host app.
+                Log.e(LOG_TAG, "Failed to start authentication. Default browser activity is not exported (SecurityException)")
+                val callback = FlutterWebAuth2Plugin.callbacks[callbackScheme]
+                callback?.error("NO_BROWSER", "No valid browser available for authentication.", e.message)
+                FlutterWebAuth2Plugin.callbacks.remove(callbackScheme)
+                finish()
             }
 
             authStarted = true

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -135,9 +135,9 @@ class AuthenticationManagementActivity : ComponentActivity() {
                 // intent-handling activity; launching the tab then throws instead of
                 // ActivityNotFoundException. Fail the attempt like the no-browser case
                 // rather than crashing the host app.
-                Log.e(LOG_TAG, "Failed to start authentication. Default browser activity is not exported (SecurityException)")
+                Log.e(LOG_TAG, "Failed to start authentication. Most likely, the selected browser activity is not exported (SecurityException)")
                 val callback = FlutterWebAuth2Plugin.callbacks[callbackScheme]
-                callback?.error("NO_BROWSER", "No valid browser available for authentication.", e.message)
+                callback?.error("SECURITY_EXCEPTION", "Selected browser cannot be accessed for authentication.", e.message)
                 FlutterWebAuth2Plugin.callbacks.remove(callbackScheme)
                 finish()
             }


### PR DESCRIPTION
Fixes #211.

## Problem

On Android devices where the user's default browser is an app whose intent-handling activity is **not exported** (several fintech apps register themselves as browsers like this — e.g. `team.opay.pay/com.opay.webview.WebFoundationActivity`), `AuthTabIntent.launch` throws `SecurityException: Permission Denial ... not exported from uid ...` instead of `ActivityNotFoundException`. The exception escapes `AuthenticationManagementActivity.onResume` and crashes the host app on every `authenticate()` call — it cannot be caught from Dart. Full stack trace in #211; we see ~535 crashes / ~130 users per month in production from this.

## Fix

Catch `SecurityException` next to the existing `ActivityNotFoundException` handler and route it through the same `NO_BROWSER` error path, so the Dart side gets a regular `PlatformException` the app can handle.

We've been running this exact patch vendored on top of 5.0.2 in production — the crash turns into the standard no-browser error flow. A 5.x backport would be much appreciated if you're doing maintenance releases.

## Testing

- Compiled and ran as part of our app build (release + debug).
- Manual repro requires a device with a non-exported default-browser app; before the patch: process crash, after: `NO_BROWSER` `PlatformException`.

CHANGELOG left untouched — happy to add an entry if you prefer contributors to do that.