### PR TITLE
fix(android): force CustomTabsIntent to bypass Moto Secure / Xiaomi AuthTab blocking

### DIFF
--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -21,6 +21,7 @@ class AuthenticationManagementActivity : ComponentActivity() {
         const val KEY_AUTH_OPTION_INTENT_FLAGS: String = "authOptionsIntentFlags"
         const val KEY_AUTH_OPTION_TARGET_PACKAGE: String = "authOptionsTargetPackage"
         const val KEY_AUTH_OPTION_PREFER_EPHEMERAL: String = "authOptionsPreferEphemeral"
+        const val KEY_AUTH_OPTION_FORCE_CUSTOM_TABS: String = "authOptionsForceCustomTabs"
         const val KEY_AUTH_CALLBACK_SCHEME: String = "authCallbackScheme"
         const val KEY_AUTH_CALLBACK_HOST: String = "authCallbackHost"
         const val KEY_AUTH_CALLBACK_PATH: String = "authCallbackPath"
@@ -37,6 +38,7 @@ class AuthenticationManagementActivity : ComponentActivity() {
     private var intentFlags: Int = 0
     private var targetPackage: String? = null
     private var preferEphemeral: Boolean = false
+    private var forceCustomTabs: Boolean = false
     private lateinit var callbackScheme: String
     private var callbackHost: String? = null
     private var callbackPath: String? = null
@@ -54,6 +56,13 @@ class AuthenticationManagementActivity : ComponentActivity() {
         } else {
             extractState(savedInstanceState)
         }
+    }
+
+
+    private fun finishWithoutAnimation() {
+        finish()
+        @Suppress("DEPRECATION")
+        overridePendingTransition(0, 0)
     }
 
     private fun handleAuthResult(result: AuthResult) {
@@ -86,11 +95,14 @@ class AuthenticationManagementActivity : ComponentActivity() {
 
         if (!authStarted) {
 
-            val intentBuilder = if (shouldUseAuthTabs()) {
+
+            val useAuthTabs = !forceCustomTabs && shouldUseAuthTabs()
+
+            val intentBuilder = if (useAuthTabs) {
                 Log.d(LOG_TAG, "Using AuthTabIntent")
                 AuthTabBuilderWrapper(AuthTabIntent.Builder())
             } else {
-                Log.d(LOG_TAG, "Using CustomTabsIntent")
+                Log.d(LOG_TAG, "Using CustomTabsIntent" + if (forceCustomTabs) " (forced)" else "")
                 CtBuilderWrapper(CustomTabsIntent.Builder())
             }
 
@@ -169,6 +181,7 @@ class AuthenticationManagementActivity : ComponentActivity() {
         outState.putInt(KEY_AUTH_OPTION_INTENT_FLAGS, intentFlags)
         outState.putString(KEY_AUTH_OPTION_TARGET_PACKAGE, targetPackage)
         outState.putBoolean(KEY_AUTH_OPTION_PREFER_EPHEMERAL, preferEphemeral)
+        outState.putBoolean(KEY_AUTH_OPTION_FORCE_CUSTOM_TABS, forceCustomTabs)
         outState.putString(KEY_AUTH_CALLBACK_SCHEME, callbackScheme)
         outState.putString(KEY_AUTH_CALLBACK_HOST, callbackHost)
         outState.putString(KEY_AUTH_CALLBACK_PATH, callbackPath)
@@ -189,6 +202,7 @@ class AuthenticationManagementActivity : ComponentActivity() {
         intentFlags = state.getInt(KEY_AUTH_OPTION_INTENT_FLAGS, 0)
         targetPackage = state.getString(KEY_AUTH_OPTION_TARGET_PACKAGE)
         preferEphemeral = state.getBoolean(KEY_AUTH_OPTION_PREFER_EPHEMERAL, false)
+        forceCustomTabs = state.getBoolean(KEY_AUTH_OPTION_FORCE_CUSTOM_TABS, false)
         callbackScheme = state.getString(KEY_AUTH_CALLBACK_SCHEME)!!
         callbackHost = state.getString(KEY_AUTH_CALLBACK_HOST)
         callbackPath = state.getString(KEY_AUTH_CALLBACK_PATH)

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/AuthenticationManagementActivity.kt
@@ -59,12 +59,6 @@ class AuthenticationManagementActivity : ComponentActivity() {
     }
 
 
-    private fun finishWithoutAnimation() {
-        finish()
-        @Suppress("DEPRECATION")
-        overridePendingTransition(0, 0)
-    }
-
     private fun handleAuthResult(result: AuthResult) {
         val callback = FlutterWebAuth2Plugin.callbacks[callbackScheme]
         if (callback == null) {

--- a/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/FlutterWebAuth2Plugin.kt
+++ b/flutter_web_auth_2/android/src/main/kotlin/com/linusu/flutter_web_auth_2/FlutterWebAuth2Plugin.kt
@@ -55,6 +55,7 @@ class FlutterWebAuth2Plugin(
                     putExtra(AuthenticationManagementActivity.KEY_AUTH_CALLBACK_HOST, options["httpsHost"] as String?)
                     putExtra(AuthenticationManagementActivity.KEY_AUTH_CALLBACK_PATH, options["httpsPath"] as String?)
                     putExtra(AuthenticationManagementActivity.KEY_AUTH_OPTION_PREFER_EPHEMERAL, options["preferEphemeral"] as Boolean? ?: false)
+                    putExtra(AuthenticationManagementActivity.KEY_AUTH_OPTION_FORCE_CUSTOM_TABS, options["forceCustomTabs"] as Boolean? ?: false)
                 })
             }
 

--- a/flutter_web_auth_2/lib/src/options.dart
+++ b/flutter_web_auth_2/lib/src/options.dart
@@ -61,12 +61,14 @@ class FlutterWebAuth2Options {
     this.httpsHost,
     this.httpsPath,
     this.customTabsPackageOrder,
+    bool? forceCustomTabs,
   })  : preferEphemeral = preferEphemeral ?? false,
         intentFlags = intentFlags ?? defaultIntentFlags,
         timeout = timeout ?? 5 * 60,
         landingPageHtml = landingPageHtml ?? _defaultLandingPage,
         silentAuth = silentAuth ?? false,
-        useWebview = useWebview ?? true;
+        useWebview = useWebview ?? true,
+        forceCustomTabs = forceCustomTabs ?? false;
 
   /// Construct an instance from JSON format.
   FlutterWebAuth2Options.fromJson(Map<String, dynamic> json)
@@ -82,6 +84,7 @@ class FlutterWebAuth2Options {
           httpsHost: json['httpsHost'],
           httpsPath: json['httpsPath'],
           customTabsPackageOrder: json['customTabsPackageOrder'],
+          forceCustomTabs: json['forceCustomTabs'],
         );
 
   /// **Only has an effect on iOS, Android and macOS!**
@@ -166,6 +169,7 @@ class FlutterWebAuth2Options {
   /// is tested etc.
   final List<String>? customTabsPackageOrder;
 
+  final bool forceCustomTabs;
   /// Convert this instance to JSON format.
   Map<String, dynamic> toJson() => {
         'preferEphemeral': preferEphemeral,
@@ -179,5 +183,6 @@ class FlutterWebAuth2Options {
         'customTabsPackageOrder': customTabsPackageOrder,
         'httpsHost': httpsHost,
         'httpsPath': httpsPath,
+        'forceCustomTabs': forceCustomTabs,
       };
 }


### PR DESCRIPTION
Motorola's Moto Secure feature ("Protect from online scammers") and Xiaomi/MIUI security apps aggressively block or cancel AuthTabIntent when apps use custom URI schemes (e.g., scheme://callback). This causes the authentication flow to immediately fail or cancel out.

Switching back to standard CustomTabsIntent solves this issue